### PR TITLE
Activate virtualenv after command prompt restart

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -109,6 +109,8 @@ You need to install your Heroku toolbelt which you can find here (you can skip t
 
 > On Windows you also must run the following command to add Git and SSH to your command prompt's `PATH`: `setx PATH "%PATH%;C:\Program Files\Git\bin"`. Restart the command prompt program afterwards to enable the change.
 
+> After restarting your command prompt, don't forget to go to your `djangogirls` folder again and activate your virtualenv! (Hint: `myvenv\Scripts\activate`)
+
 Please also create a free Heroku account here: https://id.heroku.com/signup/www-home-top
 
 Then authenticate your Heroku account on your computer by running this command:


### PR DESCRIPTION
My team got quite confused when they had to reopen the command line after doing the Heroku thingies and the next commands weren't working. It would be nice to have a reminder here because activating the virtualenv was ages ago :)
